### PR TITLE
Feature/radio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ CSRC = $(ALLCSRC) \
        $(PROJECT_DIRECTORY)/src/driver/led/led.c \
        $(PROJECT_DIRECTORY)/src/driver/spi/spi.c \
        $(PROJECT_DIRECTORY)/src/driver/button/button.c \
+       $(PROJECT_DIRECTORY)/src/driver/radio/nrf52_radio.c \
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.
@@ -158,9 +159,10 @@ ASMSRC = $(ALLASMSRC)
 ASMXSRC = $(ALLXASMSRC)
 
 INCDIR = $(CONFDIR) $(ALLINC) $(TESTINC) $(TESTHAL) \
-		 $(PROJECT_DIRECTORY)/src/driver/led \
-		 $(PROJECT_DIRECTORY)/src/driver/spi \
-		 $(PROJECT_DIRECTORY)/src/driver/button \
+		$(PROJECT_DIRECTORY)/src/driver/led \
+		$(PROJECT_DIRECTORY)/src/driver/spi \
+		$(PROJECT_DIRECTORY)/src/driver/button \
+		$(PROJECT_DIRECTORY)/src/driver/radio \
 
 #
 # Project, sources and paths

--- a/gdb/dwm1001.gdb
+++ b/gdb/dwm1001.gdb
@@ -1,0 +1,13 @@
+file "./build/dis_loc_dwm1001.elf"
+
+set architecture auto
+set remote hardware-breakpoint-limit 6
+set remote hardware-watchpoint-limit 4
+
+target extended-remote :3333
+
+load
+tbreak main
+
+continue
+

--- a/openocd/dwm1001.cfg
+++ b/openocd/dwm1001.cfg
@@ -3,3 +3,5 @@ source [find interface/jlink.cfg]
 transport select swd
 
 source [find target/nrf52.cfg]
+
+$_TARGETNAME configure -rtos ChibiOS

--- a/src/driver/radio/nrf52_radio.c
+++ b/src/driver/radio/nrf52_radio.c
@@ -235,6 +235,7 @@ static THD_FUNCTION(rfPostThread, arg) {
         radio_read_rx_payload(&rx_payload);
         // Here we process the payload
         // if(rx_payload.pipe == RADIO_MY_ID) // It is for me
+        // if(rx_payload.pipe == 0) // It is for everybody broadcast
         // switch / case for the rx_payload.data[0] to check the Packet ID and decode the rest
 
         toggle_led(green);

--- a/src/driver/radio/nrf52_radio.h
+++ b/src/driver/radio/nrf52_radio.h
@@ -44,6 +44,27 @@
 #define NRF52_RADIO_PPI_RX_TIMEOUT          12                  /**< The PPI channel used for RX timeout. */
 #define NRF52_RADIO_PPI_TX_START            13                  /**< The PPI channel used for starting TX. */
 
+#ifndef RADIO_ESB_BASE_ADDR_P0
+#define RADIO_ESB_BASE_ADDR_P0 {0xF3, 0xF3, 0xF3, 0xF3}
+#endif
+
+#ifndef RADIO_ESB_BASE_ADDR_P1
+#define RADIO_ESB_BASE_ADDR_P1 {0x3F, 0x3F, 0x3F, 0x3F}
+#endif
+
+#ifndef RADIO_ESB_PIPE_PREFIXES
+#define RADIO_ESB_PIPE_PREFIXES {0xF3, 0x3F, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6}
+#endif
+
+#define RADIO_ESB_NUM_PIPES 8
+#define RADIO_ESB_ADDR_LENGTH 5
+#define RADIO_ESB_RX_PIPES 0xFF
+#define RADIO_ESB_RF_CHANNEL 56
+
+#define RADIO_ESB_RETRANSMIT_DELAY 1000
+#define RADIO_ESB_RETRANSMIT_COUNT 3
+
+#define RADIO_ESB_STATIC_PAYLOAD_LENGTH 0
 
 typedef enum {
 	NRF52_SUCCESS,                                        /* Call was successful.                  */

--- a/src/driver/radio/nrf52_radio.h
+++ b/src/driver/radio/nrf52_radio.h
@@ -74,9 +74,9 @@
 
 #define RADIO_ESB_STATIC_PAYLOAD_LENGTH 0
 
-// Dummy network, by default ID 0
+// Dummy network, by default ID 1. We reserve 0 for broadcast
 #ifndef RADIO_MY_ID
-#define RADIO_MY_ID 0
+#define RADIO_MY_ID 1
 #endif
 
 typedef enum {

--- a/src/main.c
+++ b/src/main.c
@@ -9,21 +9,35 @@ int main(void) {
     halInit();
     chSysInit();
 
+//  Leds off
     leds_off(ALL_LEDS);
+//  LED SUMMARY
+//  Blue for the heartbeep
+//  Green for PCK_RECEIVED between internal radios
 
+//  Internal radio nrf52 init
     radio_init(&radiocfg);
     radio_flush_tx();
     radio_flush_rx();
     radio_start_rx();
 
-//    chThdCreateStatic(waRadioThread, sizeof(waRadioThread), NORMALPRIO, RadioThread, NULL);
-
     chThdSleep(2);
-
-//    NRF_P0->DETECTMODE = 0;
 
     while (true) {
         toggle_led(blue);
         chThdSleepMilliseconds(500);
+
+        // example of dummy transmission (it is configured so that there is ACK)
+        uint8_t neighborh_id = 1; // Destination between 0 and 7
+        tx_payload.pipe = neighborh_id;
+        tx_payload.noack = 0;
+        tx_payload.data[0] = 0x03; // Packet ID
+        tx_payload.data[1] = 0x33; // Payload
+        tx_payload.length = 2;
+
+        radio_stop_rx();
+        // tx_payload and rx_payload are GLOBAL and they are not thread-safe now
+        radio_write_payload(&tx_payload);
+        radio_start_tx(); // Either fail or success TX (with or w/o ACK), the radio_start_rx is called afterward
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ int main(void) {
         chThdSleepMilliseconds(500);
 
         // example of dummy transmission (it is configured so that there is ACK)
-        uint8_t neighborh_id = 1; // Destination between 0 and 7
+        uint8_t neighborh_id = 0; // Destination between 0 and 7, we reserver 0 for broadcast
         tx_payload.pipe = neighborh_id;
         tx_payload.noack = 0;
         tx_payload.data[0] = 0x03; // Packet ID

--- a/src/main.c
+++ b/src/main.c
@@ -32,12 +32,6 @@ int main(void) {
     uint8_t red1 = RED_LED_D11;
     uint8_t red2 = RED_LED_D12;
 
-    // Power off the leds.
-    palSetPad(IOPORT1, green); 
-    palSetPad(IOPORT1, blue);
-    palSetPad(IOPORT1, red1);
-    palSetPad(IOPORT1, red2);
-
     chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO+1,
       Thread1, NULL);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,45 +1,29 @@
 #include "ch.h"
 #include "hal.h"
 
-static THD_WORKING_AREA(waThread1, 64);
-
-static THD_FUNCTION(Thread1, arg) {
-
-    (void)arg;
-    //uint8_t green = GREEN_LED_D9;
-    //uint8_t blue = BLUE_LED_D10;
-    uint8_t red1 = RED_LED_D11;
-    //uint8_t red2 = RED_LED_D12;
-
-    chRegSetThreadName("blinker");
-
-    while (1) {
-      //palTogglePad(IOPORT1, green);
-      //palTogglePad(IOPORT1, blue);
-      palTogglePad(IOPORT1, red1);
-      //palTogglePad(IOPORT1, red2);
-      chThdSleepMilliseconds(100);
-    }
-}
+#include "led.h"
+#include "nrf52_radio.h"
 
 int main(void) {
 
     halInit();
     chSysInit();
 
-    uint8_t green = GREEN_LED_D9;
-    uint8_t blue = BLUE_LED_D10;
-    uint8_t red1 = RED_LED_D11;
-    uint8_t red2 = RED_LED_D12;
+    leds_off(ALL_LEDS);
 
-    chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO+1,
-      Thread1, NULL);
+    radio_init(&radiocfg);
+    radio_flush_tx();
+    radio_flush_rx();
+    radio_start_rx();
+
+//    chThdCreateStatic(waRadioThread, sizeof(waRadioThread), NORMALPRIO, RadioThread, NULL);
 
     chThdSleep(2);
 
 //    NRF_P0->DETECTMODE = 0;
 
     while (true) {
-        chThdSleepMilliseconds(250);
+        toggle_led(blue);
+        chThdSleepMilliseconds(500);
     }
 }


### PR DESCRIPTION
Soporte a la radio.

El protocolo simple que hay implementado te permite tener una lista de hasta seis vecinos (1-7) / MY_ID + y reservamos el 0 para.
En el momento de compilación hay que pasar -DRADIO_MY_ID x   x \in [1,..,7].

El main thread incluye un ejemplo de transmissión, y en el hilo rfPostproTXRX se postprocesan los pkts recividos.